### PR TITLE
Add 'url' field to fetcher items

### DIFF
--- a/cms/astro/src/lib/directus/fetchers.ts
+++ b/cms/astro/src/lib/directus/fetchers.ts
@@ -206,6 +206,7 @@ export const fetchSiteData = async () => {
               items: [
                 'id',
                 'title',
+                'url',
                 {
                   page: ['permalink'],
                   children: ['id', 'title', 'url', { page: ['permalink'] }],
@@ -225,6 +226,7 @@ export const fetchSiteData = async () => {
               items: [
                 'id',
                 'title',
+                'url',
                 {
                   page: ['permalink'],
                   children: ['id', 'title', 'url', { page: ['permalink'] }],


### PR DESCRIPTION
url field was missing from main and footer navigation. Resulting in url not working for main menu items, only for child menu items.