### PR TITLE
fix: correct form fields in next.js

### DIFF
--- a/cms/nextjs/src/components/forms/DynamicForm.tsx
+++ b/cms/nextjs/src/components/forms/DynamicForm.tsx
@@ -47,7 +47,6 @@ const DynamicForm = ({ fields, onSubmit, submitLabel, id }: DynamicFormProps) =>
 		<Form {...form}>
 			<form
 				onSubmit={form.handleSubmit(onSubmit)}
-				className="flex flex-wrap gap-4"
 				data-directus={setAttr({
 					collection: 'forms',
 					item: id,
@@ -55,21 +54,20 @@ const DynamicForm = ({ fields, onSubmit, submitLabel, id }: DynamicFormProps) =>
 					mode: 'popover',
 				})}
 			>
-				{sortedFields.map((field) => (
-					<div key={field.id} className="w-full">
-						<Field key={field.id} field={field} form={form} />
-					</div>
-				))}
-				<div className="w-full">
-					<div
-						data-directus={setAttr({
-							collection: 'forms',
-							item: id,
-							fields: 'submit_label',
-							mode: 'popover',
-						})}
-					>
-						<Button type="submit" label={submitLabel} icon="arrow" iconPosition="right" id={`submit-${id}`} />
+				<div className="flex flex-wrap gap-4">
+					{sortedFields.map((field) => <Field key={field.id} field={field} form={form} />)}
+
+					<div className="w-full">
+						<div
+							data-directus={setAttr({
+								collection: 'forms',
+								item: id,
+								fields: 'submit_label',
+								mode: 'popover',
+							})}
+						>
+							<Button type="submit" label={submitLabel} icon="arrow" iconPosition="right" id={`submit-${id}`} />
+						</div>
 					</div>
 				</div>
 			</form>


### PR DESCRIPTION
Form fields in Next template had always full width, before:
<img width="1181" height="481" alt="image" src="https://github.com/user-attachments/assets/d175363d-73f1-43eb-9a6f-c9828c0840c4" />
after (the same as in nuxt template):
<img width="1166" height="386" alt="image" src="https://github.com/user-attachments/assets/b8ba8f18-800f-4479-8aa0-1578cf01f112" />
