### PR TITLE
Update Directus image to 12.1.1

### DIFF
--- a/_shared/docker-compose.yaml
+++ b/_shared/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
       start_period: 30s
 
   directus:
-    image: directus/directus:12.0.0
+    image: directus/directus:12.1.1
     ports:
       - ${DIRECTUS_PORT}:8055
     volumes:

--- a/blank/directus/docker-compose.yaml
+++ b/blank/directus/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
       start_period: 30s
 
   directus:
-    image: directus/directus:12.0.0
+    image: directus/directus:12.1.1
     ports:
       - ${DIRECTUS_PORT}:8055
     volumes:

--- a/cms-i18n/directus/docker-compose.yaml
+++ b/cms-i18n/directus/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
       start_period: 30s
 
   directus:
-    image: directus/directus:12.0.0
+    image: directus/directus:12.1.1
     ports:
       - ${DIRECTUS_PORT}:8055
     volumes:

--- a/cms/directus/docker-compose.yaml
+++ b/cms/directus/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
       start_period: 30s
 
   directus:
-    image: directus/directus:12.0.0
+    image: directus/directus:12.1.1
     ports:
       - ${DIRECTUS_PORT}:8055
     volumes:


### PR DESCRIPTION
## Changes

- Updates Directus Docker image pins from 12.0.0 to 12.1.1 across shared, blank, CMS, and CMS i18n compose files.
- Keeps all starter templates on the latest stable Directus v12 image.

## Potential Risks

- Local users pulling this change will download a newer Directus image on next compose startup.

## Review Notes

- Verified template validation passes and a clean CMS template apply succeeds against Directus 12.1.1.