### PR TITLE
Add Frontend Bot email to templates

### DIFF
--- a/_scripts/validate-templates.js
+++ b/_scripts/validate-templates.js
@@ -89,6 +89,7 @@ function validateTemplateDir(templateName, basePath, templateRelPath, label) {
   }
 
   validateSingletonContent(templateName, srcPath)
+  validateUsers(templateName, srcPath, label)
 }
 
 // Validate Directus template files
@@ -133,6 +134,17 @@ function validateSingletonContent(templateName, srcPath) {
         templateName,
         `content/${translationsFile}.json must not exist — nest translations inside content/${collection}.json (template-cli loads singletons last)`,
       )
+    }
+  }
+}
+
+function validateUsers(templateName, srcPath, label) {
+  const users = readJson(join(srcPath, 'users.json'))
+  if (!users) return
+
+  for (const user of users) {
+    if (typeof user.email !== 'string' || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(user.email)) {
+      error(templateName, `${label}/src/users.json user ${user.id || '<unknown>'} must have a valid email`)
     }
   }
 }

--- a/cms-i18n/directus/template/src/users.json
+++ b/cms-i18n/directus/template/src/users.json
@@ -3,7 +3,7 @@
     "id": "88a6e8cf-f0f8-41db-a3a2-8a9741c086cc",
     "first_name": "Frontend",
     "last_name": "Bot",
-    "email": null,
+    "email": "frontend-bot@example.com",
     "password": null,
     "location": null,
     "title": "For server-to-server communication",

--- a/cms/directus/template-licensed/src/users.json
+++ b/cms/directus/template-licensed/src/users.json
@@ -3,7 +3,7 @@
     "id": "88a6e8cf-f0f8-41db-a3a2-8a9741c086cc",
     "first_name": "Frontend",
     "last_name": "Bot",
-    "email": null,
+    "email": "frontend-bot@example.com",
     "password": null,
     "location": null,
     "title": "For server-to-server communication",

--- a/cms/directus/template/src/users.json
+++ b/cms/directus/template/src/users.json
@@ -3,7 +3,7 @@
     "id": "88a6e8cf-f0f8-41db-a3a2-8a9741c086cc",
     "first_name": "Frontend",
     "last_name": "Bot",
-    "email": null,
+    "email": "frontend-bot@example.com",
     "password": null,
     "location": null,
     "title": "For server-to-server communication",


### PR DESCRIPTION
## Changes

- Sets the Frontend Bot seed user email to `frontend-bot@example.com` across CMS, CMS licensed, and CMS i18n Directus templates.
- Adds template validation that fails when seeded Directus users do not have valid email addresses.

## Potential Risks

- Fresh template applies should stop failing on Directus user email validation; existing local instances are unaffected.

## Review Notes

- Keeps the Frontend Bot user because it owns the least-privilege Forms - Submission access used for server-side frontend form handling.