### PR TITLE
Add CMS admin bootstrap env

### DIFF
--- a/_scripts/validate-templates.js
+++ b/_scripts/validate-templates.js
@@ -162,6 +162,31 @@ function validateDocker(template) {
       error(template.name, `Missing ${file} in directus/`)
     }
   }
+
+  validateDirectusAdminEnv(template.name, directusDir)
+}
+
+function validateDirectusAdminEnv(templateName, directusDir) {
+  const envPath = join(directusDir, '.env.example')
+  const composePath = join(directusDir, 'docker-compose.yaml')
+  if (!existsSync(envPath) || !existsSync(composePath)) return
+
+  const env = readFileSync(envPath, 'utf8')
+  const compose = readFileSync(composePath, 'utf8')
+  const requiredEnv = {
+    ADMIN_EMAIL: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+    ADMIN_PASSWORD: /.+/,
+  }
+
+  for (const [key, pattern] of Object.entries(requiredEnv)) {
+    const match = env.match(new RegExp(`^${key}=(.*)$`, 'm'))
+    if (!match || !pattern.test(match[1])) {
+      error(templateName, `directus/.env.example must define ${key}`)
+    }
+    if (!compose.includes(`${key}: \${${key}}`)) {
+      error(templateName, `directus/docker-compose.yaml must pass ${key} to Directus`)
+    }
+  }
 }
 
 // Validate frontend directories

--- a/_scripts/validate-templates.js
+++ b/_scripts/validate-templates.js
@@ -143,7 +143,7 @@ function validateUsers(templateName, srcPath, label) {
   if (!users) return
 
   for (const user of users) {
-    if (typeof user.email !== 'string' || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(user.email)) {
+    if (user.email != null && (typeof user.email !== 'string' || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(user.email))) {
       error(templateName, `${label}/src/users.json user ${user.id || '<unknown>'} must have a valid email`)
     }
   }

--- a/_shared/.env.example
+++ b/_shared/.env.example
@@ -6,6 +6,8 @@ DB_DATABASE=directus
 # Directus Configuration
 DIRECTUS_PORT=8055
 DIRECTUS_SECRET=6116487b-cda1-52c2-b5b5-c8022c45e263
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=d1r3ctu5
 
 # License Configuration (optional)
 # Directus 12 runs on the free core tier without a key. Add a license key to

--- a/_shared/docker-compose.yaml
+++ b/_shared/docker-compose.yaml
@@ -41,6 +41,8 @@ services:
         condition: service_healthy
     environment:
       SECRET: ${DIRECTUS_SECRET}
+      ADMIN_EMAIL: ${ADMIN_EMAIL}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD}
       LICENSE_KEY: ${LICENSE_KEY:-}
       NODE_ENV: ${NODE_ENV:-production}
 

--- a/cms-i18n/directus/.env.example
+++ b/cms-i18n/directus/.env.example
@@ -6,6 +6,8 @@ DB_DATABASE=directus
 # Directus Configuration
 DIRECTUS_PORT=8055
 DIRECTUS_SECRET=6116487b-cda1-52c2-b5b5-c8022c45e263
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=d1r3ctu5
 
 # License (required for this starter)
 # Set before apply, or add in Studio under Settings -> License.

--- a/cms-i18n/directus/docker-compose.yaml
+++ b/cms-i18n/directus/docker-compose.yaml
@@ -41,6 +41,8 @@ services:
         condition: service_healthy
     environment:
       SECRET: ${DIRECTUS_SECRET}
+      ADMIN_EMAIL: ${ADMIN_EMAIL}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD}
       LICENSE_KEY: ${LICENSE_KEY:-}
       NODE_ENV: ${NODE_ENV:-production}
 

--- a/cms-i18n/directus/template/src/users.json
+++ b/cms-i18n/directus/template/src/users.json
@@ -3,7 +3,7 @@
     "id": "88a6e8cf-f0f8-41db-a3a2-8a9741c086cc",
     "first_name": "Frontend",
     "last_name": "Bot",
-    "email": "frontend-bot@example.com",
+    "email": null,
     "password": null,
     "location": null,
     "title": "For server-to-server communication",

--- a/cms/directus/.env.example
+++ b/cms/directus/.env.example
@@ -6,6 +6,8 @@ DB_DATABASE=directus
 # Directus Configuration
 DIRECTUS_PORT=8055
 DIRECTUS_SECRET=6116487b-cda1-52c2-b5b5-c8022c45e263
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=d1r3ctu5
 
 # License Configuration (optional)
 # Directus 12 runs on the free core tier without a key. Add a license key to

--- a/cms/directus/docker-compose.yaml
+++ b/cms/directus/docker-compose.yaml
@@ -41,6 +41,8 @@ services:
         condition: service_healthy
     environment:
       SECRET: ${DIRECTUS_SECRET}
+      ADMIN_EMAIL: ${ADMIN_EMAIL}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD}
       LICENSE_KEY: ${LICENSE_KEY:-}
       NODE_ENV: ${NODE_ENV:-production}
 

--- a/cms/directus/template-licensed/src/users.json
+++ b/cms/directus/template-licensed/src/users.json
@@ -3,7 +3,7 @@
     "id": "88a6e8cf-f0f8-41db-a3a2-8a9741c086cc",
     "first_name": "Frontend",
     "last_name": "Bot",
-    "email": "frontend-bot@example.com",
+    "email": null,
     "password": null,
     "location": null,
     "title": "For server-to-server communication",

--- a/cms/directus/template/src/users.json
+++ b/cms/directus/template/src/users.json
@@ -3,7 +3,7 @@
     "id": "88a6e8cf-f0f8-41db-a3a2-8a9741c086cc",
     "first_name": "Frontend",
     "last_name": "Bot",
-    "email": "frontend-bot@example.com",
+    "email": null,
     "password": null,
     "location": null,
     "title": "For server-to-server communication",


### PR DESCRIPTION
## Changes

- Adds `ADMIN_EMAIL` and `ADMIN_PASSWORD` to the CMS and CMS i18n Directus env examples.
- Passes those variables into the Directus containers so the first admin user is created before template apply runs.
- Restores the Frontend Bot user email to `null` and keeps validation limited to malformed non-null emails.
- Adds template validation to require valid admin bootstrap env in non-blank backend templates.

## Potential Risks

- These are local starter defaults copied into fresh projects; users should change them for real deployments.

## Review Notes

- The reproduced `init` failure was the CLI passing missing admin credentials, not the Frontend Bot seed user. `directus-template-cli@0.8.0` strips `email: null` before creating template users.