### PR TITLE
Remove custom CSS from starter backends

### DIFF
--- a/cms-i18n/directus/template/src/settings.json
+++ b/cms-i18n/directus/template/src/settings.json
@@ -31,7 +31,6 @@
       "transforms": []
     }
   ],
-  "custom_css": ".v-divider.inlineTitle.large.add-margin-top {\n    margin-top: 0 !important;\n}\n\nbody {\n    font-size: 16px !important;\n}\n\n.drawer-item-content {\n   --theme--form--row-gap: 16px;\n   --theme--form--column-gap: 32px;\n}\n\n#overlay-outlet {\n   --theme--form--row-gap: 16px;\n   --theme--form--column-gap: 32px;\n}\n    ",
   "storage_default_folder": "ece7bab9-5433-4a63-b9f7-bde8b517d6d9",
   "basemaps": null,
   "mapbox_key": null,

--- a/cms/directus/template-licensed/src/settings.json
+++ b/cms/directus/template-licensed/src/settings.json
@@ -31,7 +31,6 @@
       "transforms": []
     }
   ],
-  "custom_css": ".v-divider.inlineTitle.large.add-margin-top {\n    margin-top: 0 !important;\n}\n\nbody {\n    font-size: 16px !important;\n}\n\n.drawer-item-content {\n   --theme--form--row-gap: 16px;\n   --theme--form--column-gap: 32px;\n}\n\n#overlay-outlet {\n   --theme--form--row-gap: 16px;\n   --theme--form--column-gap: 32px;\n}\n    ",
   "storage_default_folder": "ece7bab9-5433-4a63-b9f7-bde8b517d6d9",
   "basemaps": null,
   "mapbox_key": null,

--- a/cms/directus/template/src/settings.json
+++ b/cms/directus/template/src/settings.json
@@ -31,7 +31,6 @@
       "transforms": []
     }
   ],
-  "custom_css": ".v-divider.inlineTitle.large.add-margin-top {\n    margin-top: 0 !important;\n}\n\nbody {\n    font-size: 16px !important;\n}\n\n.drawer-item-content {\n   --theme--form--row-gap: 16px;\n   --theme--form--column-gap: 32px;\n}\n\n#overlay-outlet {\n   --theme--form--row-gap: 16px;\n   --theme--form--column-gap: 32px;\n}\n    ",
   "storage_default_folder": "ece7bab9-5433-4a63-b9f7-bde8b517d6d9",
   "basemaps": null,
   "mapbox_key": null,


### PR DESCRIPTION
## Changes

- Removes the custom Directus Admin CSS from CMS, licensed CMS, and CMS i18n backend snapshots.

## Potential Risks

- Existing deployments are unaffected; future template applications use Directus default Admin styling.

## Review Notes

- `npm run validate` passes; it still reports the existing shared scaffold warnings.